### PR TITLE
Ändra om kodstruktur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.pro.user
 
 # Generated directory
-build-src-*
+build-*
 
 # Prerequisites
 *.d

--- a/Calviton.pro
+++ b/Calviton.pro
@@ -12,7 +12,7 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
-SOURCES +=         main.cpp
+SOURCES +=         src/main.cpp
 
 # Additional import path used to resolve QML modules in Qt Creator's code model
 QML_IMPORT_PATH = /opt/Qt-5.12.0/5.12.0/gcc_64/qml
@@ -25,9 +25,9 @@ qnx: target.path = /tmp/$${TARGET}/bin
 else: unix:!android: target.path = /opt/$${TARGET}/bin
 !isEmpty(target.path): INSTALLS += target
 
-RESOURCES +=     qml.qrc
+RESOURCES +=     src/qml.qrc
 
-DISTFILES +=     main.qml
+DISTFILES +=     src/main.qml
 
 unix: {
     linux-g++ { # Qt5 x86

--- a/src/MapView.qml
+++ b/src/MapView.qml
@@ -1,0 +1,31 @@
+import QtQuick 2.0
+
+import QtQuick.Window 2.0
+import QtLocation 5.6
+import QtPositioning 5.6
+
+Rectangle {
+    Rectangle {
+        height: parent.height
+        width: parent.width * 2 / 3
+        anchors.left: parent.left
+        anchors.top: parent.top
+
+        Map {
+            anchors.fill: parent
+            plugin: mapboxglPlugin
+            center: QtPositioning.coordinate(59.86, 17.64)
+            zoomLevel: 14
+        }
+    }
+
+    Rectangle {
+        height: parent.height
+        width: parent.width * 1 / 3
+        anchors.right: parent.right
+
+        Text {
+            text: "Map"
+        }
+    }
+}

--- a/src/NavigationView.qml
+++ b/src/NavigationView.qml
@@ -1,0 +1,31 @@
+import QtQuick 2.0
+
+import QtQuick.Window 2.0
+import QtLocation 5.6
+import QtPositioning 5.6
+
+Rectangle {
+    Rectangle {
+        height: parent.height
+        width: parent.width * 2 / 3
+        anchors.left: parent.left
+        anchors.top: parent.top
+
+        Map {
+            anchors.fill: parent
+            plugin: mapboxglPlugin
+            center: QtPositioning.coordinate(59.86, 17.64)
+            zoomLevel: 14
+        }
+    }
+
+    Rectangle {
+        height: parent.height
+        width: parent.width * 1 / 3
+        anchors.right: parent.right
+
+        Text {
+            text: "Navigation"
+        }
+    }
+}

--- a/src/RouteView.qml
+++ b/src/RouteView.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.0
+
+Rectangle {
+    Text {
+        text: "Routes"
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
     view->rootContext()->setContextProperty("displayHeight", QVariant(displayHeight));
 
     view->setSource(QStringLiteral("qrc:/main.qml"));
-    view->show();
+    view->showNormal();
 
     return app.exec();
 }

--- a/src/main.qml
+++ b/src/main.qml
@@ -95,30 +95,7 @@ Item {
             NavigationView {
                 id: navigationView
                 visible: view.view === this
-<<<<<<< Updated upstream
-
-                Rectangle {
-                    height: parent.height
-                    width: parent.width * 2 / 3
-                    anchors.left: parent.left
-                    anchors.top: parent.top
-
-                    Map {
-                        anchors.fill: parent
-                        plugin: mapboxglPlugin
-                        center: QtPositioning.coordinate(59.86, 17.64)
-                        zoomLevel: 14
-                    }
-                }
-
-                Rectangle {
-                    height: parent.height
-                    width: parent.width /3
-                    anchors.right: parent.right
-                }
-=======
                 anchors.fill: parent
->>>>>>> Stashed changes
             }
         }
     }

--- a/src/main.qml
+++ b/src/main.qml
@@ -74,48 +74,28 @@ Item {
 
         Rectangle {
             id: view
-            property Item view: mapView
+            property Item view: routeView
             width: parent.width - menu.width
             height: parent.height
             anchors.left: parent.left
             anchors.top: parent.top
 
-            Rectangle {
+            RouteView {
                 id: routeView
-                anchors.fill: parent
                 visible: view.view === this
+                anchors.fill: parent
             }
 
-            Rectangle {
+            MapView {
                 id: mapView
-                anchors.fill: parent
                 visible: view.view === this
-
-                Rectangle {
-                    height: parent.height
-                    width: parent.width * 2 / 3
-                    anchors.left: parent.left
-                    anchors.top: parent.top
-
-                    Map {
-                        anchors.fill: parent
-                        plugin: mapboxglPlugin
-                        center: QtPositioning.coordinate(59.86, 17.64)
-                        zoomLevel: 14
-                    }
-                }
-
-                Rectangle {
-                    height: parent.height
-                    width: parent.width * 1 / 3
-                    anchors.right: parent.right
-                }
+                anchors.fill: parent
             }
 
-            Rectangle {
+            NavigationView {
                 id: navigationView
-                anchors.fill: parent
                 visible: view.view === this
+<<<<<<< Updated upstream
 
                 Rectangle {
                     height: parent.height
@@ -136,6 +116,9 @@ Item {
                     width: parent.width /3
                     anchors.right: parent.right
                 }
+=======
+                anchors.fill: parent
+>>>>>>> Stashed changes
             }
         }
     }

--- a/src/qml.qrc
+++ b/src/qml.qrc
@@ -1,5 +1,8 @@
 <RCC>
     <qresource prefix="/">
         <file>main.qml</file>
+        <file>MapView.qml</file>
+        <file>RouteView.qml</file>
+        <file>NavigationView.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
QML-filer är uppdelade, så nu är det lättare att jobba bland de olika filerna.
Projektet har även rätt namn (och fönstertitel) när man öppnar den med Qt Creator.