### PR TITLE
Snabbare karta för display

### DIFF
--- a/src/MapView.qml
+++ b/src/MapView.qml
@@ -40,6 +40,7 @@ Rectangle {
             minimumZoomLevel: 0
             maximumZoomLevel: 20
 
+            // MapBoxGL parameters. These parameters don't work with regular MapBox.
             MapParameter {
                 type: "paint"
 

--- a/src/main.qml
+++ b/src/main.qml
@@ -27,14 +27,12 @@ Item {
 
     Plugin {
         id: mapboxPlugin
-        name: "mapboxgl"
-        //parameters: [
-            //PluginParameter{
-                //name: "osm.useragent"; value: "crossdump"
-            //}]
+        name: "mapbox"
+        PluginParameter {
+            name: "mapbox.access_token"
+            value: "pk.eyJ1IjoiY2Fsdml0b24iLCJhIjoiY2s4anVncTFtMDRhcDNmbWtveXpua2kzbSJ9.mkdCbAYVquQK_uljD4_p0A"
+        }
     }
-
-
 
     Rectangle {
         anchors.centerIn: parent


### PR DESCRIPTION
Kartan presterar mycket bättre genom att ändra från mapboxgl till mapbox som map plugin.

Vi kan ha access token pushad till repot för tillfället.