### PR TITLE
Rotate driver arrow according to map rotation

### DIFF
--- a/src/MapView.qml
+++ b/src/MapView.qml
@@ -72,7 +72,7 @@ Rectangle {
             activeMapType: supportedMapTypes[theme.mapType]
             MapQuickItem {
                 id: startMarker
-                rotation: traveler.direction
+                rotation: traveler.direction - map.bearing
 
                 sourceItem: Image {
                     id: driverIcon


### PR DESCRIPTION
Testa genom att sätta `Map`-komponentens `bearing`-property t.ex. till `90`.
Pilen startar vriden men det viktiga är att den har rätt vinkel när man drar runt pilen.